### PR TITLE
[Bug] Fix "plugin not found" with verdaccio 5

### DIFF
--- a/rollup.js
+++ b/rollup.js
@@ -43,7 +43,7 @@ async function createBundle(options) {
 }
 
 async function build() {
-  const clientBundles = [3, 4].map(version => () =>
+  const clientBundles = [3, 4, 5].map(version => () =>
     createBundle({
       target: "client",
       input: `src/client/verdaccio-${version}.ts`,


### PR DESCRIPTION
## Bug Report

#### Versions

|                           | Version |
| ------------------------- | ------- |
| verdaccio                 |     5.x    |
| verdaccio-gitlab-oauth2 |   1.0.10      |

#### Expected behavior
The plugin should be found in Verdaccio 5

#### Observed behaviour
When adding the verdaccio-gitlab-oauth2 plugin, we get : 
`plugin not found. try npm install`

See #3 

The problem seems to be that the verdaccio-5.js file is not imported in dist/public directory.
I think we can fix that by adding the verdaccio 5 version in the build function in rollup.js file.